### PR TITLE
V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,38 @@
-# DNAnexus polyedge v1.0.0
+# DNAnexus PolyEdge
 
-Uses [polyedge v1.0.0](https://github.com/moka-guys/polyedge/tree/v1.0.0) to determine if a known variant is present at 
-the base preceeding a poly stretch in a BAM file. Lists the count of each allele at that position, along with other 
-metrics (detailed at [polyedge v1.0.0](https://github.com/moka-guys/polyedge/tree/v1.0.0)). This version identifies the 
-pathogenic A>T SNV at +3 of intron 5 of the MSH2 gene. 
+Uses [polyedge v1.1.0](https://github.com/moka-guys/polyedge) to find variants at the 5' end of a poly stretch of varying length in a BAM file. Lists the count of each allele at that position, along with other metrics (detailed at [polyedge v1.1.0](https://github.com/moka-guys/polyedge)).
 
-This provides a solution to the alignment issues caused by poly repeat stretches, whereby the aligner spreads the 
-variant across adjacent bases and dilutes it to a point where the standard variant caller cannot detect it.
+This provides a solution to the alignment issues caused by poly repeat stretches, whereby the aligner spreads the variant across adjacent bases and dilutes it to a point where the standard variant caller cannot detect it.
+
+## How does this app work?
+
+If `skip` is `true` the app closes without downloading any inputs. This allows us to embed the app in a generic workflow that would run samples where MSH2 is not a gene of interest.
+
+Otherwise, the app downloads the polyedge dockerfile from 001_ToolsReferenceData, and the input files, runs the docker, and captures the stdout into the output file.
 
 ## Inputs
+
 - `BAM` - BAM file
 - `BAI` - BAM index file
+- `gene` - Gene of interest
+- `poly_start` - Start position of poly stretch (0-based)
+- `poly_end` - End position of poly stretch (0-based)
+- `chrom` - Chromosome of interest
+- `anchor_length` - Length of anchor sequence (Default is 2. It is *NOT* recommended to change this from the default)
 - `skip` - boolean (default `true`)
 
 ## Outputs
-- `*msh2_polyedge.txt` - file (output to `/MSH2_polyedge`)
 
-`*msh2_polyedge.txt` is a  tab delimited file describing all alleles seen at that position. Please see the 
-[polyedge readme](https://github.com/moka-guys/polyedge#output) for a more detailed description.
+- `polyedge_csv` - CSV output with per-allele metrics
+- `polyedge_pdf` - HTML output with per-allele metrics
+- `polyedge_html` - PDF output with per-allele metrics
 
-## How does this app work?
-If skip is true the app closes without downloading any inputs. This allows us to embed the app in a generic workflow
-that would run samples where MSH2 is not a gene of interest.
+This array of files contains the following:
 
-Otherwise, the app downloads the polyedge dockerfile from 001_ToolsReferenceData, and the input files, runs the docker, 
-and captures the stdout into the output file.
+- CSV file containing raw data - `$SAMPLENAME.refined.$GENE_polyedge.csv`
+- HTML report - `$SAMPLENAME.refined.$GENE_polyedge.html`
+- PDF report - `$SAMPLENAME.refined.$GENE_polyedge.pdf`
+  
+These files describe the alleles seen at the position of interest (this position is the `poly_start` position, and whilst the app input is a 0-based coordinate, it is displayed in the output files as a 1-based coordinate). Further details on the output files can be found in the readme at [polyedge v1.1.0](https://github.com/moka-guys/polyedge).
 
-### This app was produced by the Viapath Genome Informatics Team.
+### This app was produced by the Synnovis Genome Informatics Team

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This provides a solution to the alignment issues caused by poly repeat stretches
 
 ## How does this app work?
 
-If `skip` is `true` the app closes without downloading any inputs. This allows us to embed the app in a generic workflow that would run samples where MSH2 is not a gene of interest.
+If `skip` is `true` the app closes without downloading any inputs. This allows us to embed the app in a generic workflow that does not require the polyedge app.
 
 Otherwise, the app downloads the polyedge dockerfile from 001_ToolsReferenceData, and the input files, runs the docker, and captures the stdout into the output file.
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "polyedge_v1.1.0",
   "title": "polyedge_v1.1.0",
-  "summary": "v1.1.0 - MSH2 polyedge.",
+  "summary": "v1.1.0 polyedge.",
   "properties": {
     "github release": "v1.1.0"
   },

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,26 +1,80 @@
 {
-  "name": "polyedge_v1.0.0",
-  "title": "polyedge_v1.0.0",
-  "summary": "v1.0.0 - MSH2 polyedge.",
+  "name": "polyedge_v1.1.0",
+  "title": "polyedge_v1.1.0",
+  "summary": "v1.1.0 - MSH2 polyedge.",
   "properties": {
-    "github release": "v1.0.0"
+    "github release": "v1.1.0"
   },
   "dxapi": "1.0.0",
   "inputSpec": [
     {
       "name": "BAM",
       "label": "BAM",
-      "help": "The BAM file",
+      "help": "BAM file",
       "class": "file",
-      "patterns": ["*.bam$"],
+      "patterns": [
+        "*.bam$"
+      ],
       "optional": true
     },
     {
       "name": "BAI",
       "label": "BAI",
-      "help": "The BAM index file",
+      "help": "BAM index file",
       "class": "file",
-      "patterns": ["*.bai"],
+      "patterns": [
+        "*.bai"
+      ],
+      "optional": true
+    },
+    {
+      "name": "gene",
+      "label": "gene",
+      "help": "Gene of interest",
+      "class": "string",
+      "patterns": [
+        "*"
+      ],
+      "optional": true
+    },
+    {
+      "name": "poly_start",
+      "label": "poly_start",
+      "help": "Start position of poly stretch (0-based). N.b. the script is currently only functional for variants at the 5' end of a poly stretch",
+      "class": "int",
+      "patterns": [
+        "*"
+      ],
+      "optional": true
+    },
+    {
+      "name": "poly_end",
+      "label": "poly_end",
+      "help": "End position of poly stretch (0-based). N.b. the script is currently only functional for variants at the 5' end of a poly stretch",
+      "class": "int",
+      "patterns": [
+        "*"
+      ],
+      "optional": true
+    },
+    {
+      "name": "chrom",
+      "label": "chrom",
+      "help": "Chromosome of interest",
+      "class": "int",
+      "patterns": [
+        "*"
+      ],
+      "optional": true
+    },
+    {
+      "name": "anchor_length",
+      "label": "anchor_length",
+      "help": "Length of anchor sequence (Default is 2. It is *NOT* recommended to change this from the default)",
+      "class": "int",
+      "patterns": [
+        "*"
+      ],
       "optional": true
     },
     {
@@ -34,10 +88,24 @@
   ],
   "outputSpec": [
     {
-      "name": "polyedge_output",
-      "label": "polyedge output",
-      "help": "polyedge output file.",
-      "class": "array:file",
+      "name": "polyedge_csv",
+      "label": "polyedge_csv",
+      "help": "CSV output with per-allele metrics",
+      "class": "file",
+      "optional": true
+    },
+    {
+      "name": "polyedge_html",
+      "label": "polyedge_html",
+      "help": "HTML output with per-allele metrics",
+      "class": "file",
+      "optional": true
+    },
+    {
+      "name": "polyedge_pdf",
+      "label": "polyedge_pdf",
+      "help": "PDF output with per-allele metrics",
+      "class": "file",
       "optional": true
     }
   ],

--- a/src/code.sh
+++ b/src/code.sh
@@ -1,26 +1,33 @@
 #!/bin/bash
 
 function main() {
-  # Causes bash to exit at any point if there is any error and output each line as it is executed - useful for debugging
-  set -e -x -o pipefail
+  set -e -x -o pipefail  # Output each line as executed, exit bash upon error
   if [ "$skip" == false ];
     then
+      input_location=/home/dnanexus/in
+      output_location=/home/dnanexus/out
+      csv_out=${output_location}/polyedge_csv/polyedge
+      html_out=${output_location}/polyedge_html/polyedge
+      pdf_out=${output_location}/polyedge_pdf/polyedge
       dx-download-all-inputs --parallel
-      mv /home/dnanexus/in/*/* /home/dnanexus/in
-      docker_fileid=project-ByfFPz00jy1fk6PjpZ95F27J:file-GK4FQYQ0jy1pZ3qV6bFkVfPy
-  		dx download ${docker_fileid}
+      # Create input and output dirs
+      mkdir -p /data ${csv_out} ${html_out} ${pdf_out}
+      mv ${input_location}/*/* /data  #  Easier to mount to docker when in one dir
 
+      docker_fileid=project-ByfFPz00jy1fk6PjpZ95F27J:file-GPkqbz80jy1XgXv1JvVZ6J9V
+  		dx download ${docker_fileid}
       # Get name of docker file (should include the version) and name of image
       docker_filename=$(dx describe ${docker_fileid} --name)
-  		docker_imagename=$(tar xfO "${docker_filename}" manifest.json | sed -E 's/.*"RepoTags":\["?([^"]*)"?.*/\1/')
-
-      # Make output folder & load docker image
-      mkdir -p ~/out/polyedge_output/MSH2_polyedge
-    	docker load < "${docker_filename}"
-
-      # '-a stderr' prints any error messages
-    	docker run -v /home/dnanexus/in:/data "${docker_imagename}" /data/"${BAM_name}" \
-    	1>~/out/polyedge_output/MSH2_polyedge/"${BAM_prefix}".msh2_polyedge.txt
-  		dx-upload-all-outputs --parallel
+      # --force-local required as if tarfile name contains a colon it tries to resolve the tarfile to a machine name
+  		docker_imagename=$(tar xfO "${docker_filename}" manifest.json --force-local | sed -E 's/.*"RepoTags":\["?([^"]*)"?.*/\1/')
+    	docker load < "${docker_filename}"  # Load docker image
+      sudo docker images
+    	docker run -v /data/:/data/ -v ${output_location}:/outputs/ "${docker_imagename}" -B /data/${BAM_name} -I /data/${BAI_name} -G ${gene} -S ${poly_start} -E ${poly_end} -C ${chrom}      
+      
+      # Move outputs into their respective output folders to delocalise into the dnanexus project
+      mv ${output_location}/*.csv ${csv_out}
+      mv ${output_location}/*.pdf ${pdf_out}
+      mv ${output_location}/*.html ${html_out}
+      dx-upload-all-outputs --parallel
   fi
   }


### PR DESCRIPTION
Update to [polyedge v1.1.0](https://github.com/moka-guys/polyedge/releases/tag/v1.1.0). This covers:
- Removal of hard coding of the pathogenic A>T SNV at +3 of intron 5 of the MSH2 gene (2:47641560), and addition of command line arguments. This means this app can be run for any variant at the 5' end of a poly stretch
- Update the output format. Replacement of output text file with PDF, HTML and CSV files. Files contain the same metrics as before with the addition of headers, the input position, and in the case of the PDF and HTML the addition of threshold-based formatting (metrics highlighted in green if they meet the threshold, in red if they do not)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_polyedge/5)
<!-- Reviewable:end -->
